### PR TITLE
feat(usage): first-class Fable rate-limit window in usage, selection, and quota dashboard

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -19285,9 +19285,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -19315,10 +19320,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the

--- a/apps/quota-dashboard/src/bun/page.ts
+++ b/apps/quota-dashboard/src/bun/page.ts
@@ -110,13 +110,14 @@ function windowRow(name, w) {
   if (!w) return "";
   const used = pct(w.usedPercent);
   const free = 100 - used;
+  const est = w.unit === "estimated" || w.estimate ? " · estimated" : "";
   return \`<div class="row">
     <div class="row-head">
       <span class="name">\${name}</span>
       <span class="free" style="color:\${tone(used)}">\${free}% free</span>
     </div>
     <div class="bar"><div class="fill" style="width:\${used}%;background:\${tone(used)}"></div></div>
-    <div class="reset">\${used}% used · \${until(w.resetsAt)}</div>
+    <div class="reset">\${used}% used · \${until(w.resetsAt)}\${est}</div>
   </div>\`;
 }
 
@@ -136,7 +137,8 @@ function seatCard(seat) {
     <div class="who">\${seat.account ?? "—"}</div>
     \${windowRow("weekly", seat.weekly)}
     \${windowRow("5-hour", seat.session)}
-    \${!seat.weekly && !seat.session ? '<div class="none">no usage windows reported</div>' : ""}
+    \${windowRow("Fable (50% cap)", seat.fable)}
+    \${!seat.weekly && !seat.session && !seat.fable ? '<div class="none">no usage windows reported</div>' : ""}
   </div>\`;
 }
 

--- a/apps/quota-dashboard/src/bun/usage.ts
+++ b/apps/quota-dashboard/src/bun/usage.ts
@@ -12,6 +12,8 @@ export type UsageWindow = {
   unit: string;
   usedPercent: number;
   resetsAt: string | null;
+  capPercent?: number | null;
+  estimate?: boolean;
 };
 
 export type UsageReport = {
@@ -34,6 +36,8 @@ export type Seat = {
   planType: string | null;
   weekly: UsageWindow | null;
   session: UsageWindow | null;
+  /** Fable model window, when the seat reports or estimates one. */
+  fable: UsageWindow | null;
   /** Set when the seat cannot report — expired token, missing credentials. */
   error: string | null;
 };
@@ -139,8 +143,9 @@ export function readSnapshot(): Snapshot {
       provider: report.provider as Seat["provider"],
       account: identities.get(report.accountLabel) ?? null,
       planType: report.planType ?? null,
-      weekly: pickWindow(windows, (s) => s.includes("week")),
+      weekly: pickWindow(windows, (s) => s.includes("week") && !s.includes("fable")),
       session: pickWindow(windows, (s) => s.includes("hour") || s.includes("session")),
+      fable: pickWindow(windows, (s) => s.includes("fable")),
       error: report.error ?? null,
     };
     (report.provider === "codex" ? codex : claude).push(seat);

--- a/docs/integrations/cli-agents.mdx
+++ b/docs/integrations/cli-agents.mdx
@@ -219,9 +219,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -249,10 +254,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -19285,9 +19285,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -19315,10 +19320,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -304,9 +304,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -334,10 +339,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -19285,9 +19285,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -19315,10 +19320,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the

--- a/packages/usage/src/UsageWindow.ts
+++ b/packages/usage/src/UsageWindow.ts
@@ -27,4 +27,6 @@ export type UsageWindow = {
   resetsAt?: string;
   /** Share of the plan available to this model-specific window. */
   capPercent?: number;
+  /** True when this window is derived from a local signal, not the provider. */
+  estimate?: boolean;
 };

--- a/packages/usage/src/fableQuotaEstimate.js
+++ b/packages/usage/src/fableQuotaEstimate.js
@@ -1,0 +1,34 @@
+/** @typedef {import("./UsageReport.ts").UsageReport} UsageReport */
+/** @typedef {import("./UsageWindow.ts").UsageWindow} UsageWindow */
+/** @typedef {import("./accountSelection.js").readAccountQuotaState} readAccountQuotaState */
+
+/**
+ * Derives a best-effort Fable window from a persisted model-scoped quota
+ * event. The Claude usage endpoint does not always report a Fable window, but
+ * a recorded Fable rejection (`<label>::fable` in account-quota-state.json)
+ * still pinpoints the cap: the window is full until the recorded reset.
+ *
+ * The derived window is marked `unit: "estimated"` and `estimate: true` so
+ * renderers can distinguish it from provider-authoritative windows.
+ *
+ * @param {UsageReport} report
+ * @param {ReturnType<typeof readAccountQuotaState>["entries"]} entries Quota-state entries, already filtered to unexpired rows.
+ * @returns {UsageReport}
+ */
+export function withFableQuotaEstimate(report, entries) {
+  if (report.provider !== "claude-code") return report;
+  if (report.windows.some((window) => window.id === "weekly-fable")) return report;
+  const entry = entries[`${report.accountLabel}::fable`];
+  if (!entry) return report;
+  /** @type {UsageWindow} */
+  const window = {
+    id: "weekly-fable",
+    label: "weekly (Fable, 50% plan cap)",
+    unit: "estimated",
+    usedPercent: 100,
+    resetsAt: new Date(entry.untilMs).toISOString(),
+    capPercent: 50,
+    estimate: true,
+  };
+  return { ...report, windows: [...report.windows, window] };
+}

--- a/packages/usage/src/getUsageForAccounts.js
+++ b/packages/usage/src/getUsageForAccounts.js
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { getAccountUsage } from "./getAccountUsage.js";
 import { readUsageCache, writeUsageCache } from "./usageCache.js";
 import { readClaudeCredentials } from "./readClaudeCredentials.js";
+import { readAccountQuotaState } from "./accountSelection.js";
+import { withFableQuotaEstimate } from "./fableQuotaEstimate.js";
 
 /** @typedef {import("@smthrs/accounts").Account} Account */
 /** @typedef {import("./UsageReport.ts").UsageReport} UsageReport */
@@ -115,6 +117,11 @@ export async function getUsageForAccounts(accounts, options = {}) {
       return getAccountUsage(d.account);
     }),
   );
+  // The usage endpoint does not always report a Fable window. When it does
+  // not, a persisted Fable quota rejection still bounds the window, so surface
+  // it as an estimated meter.
+  const quotaEntries = readAccountQuotaState(env, nowMs).entries;
+  const withEstimates = reports.map((report) => withFableQuotaEstimate(report, quotaEntries));
   let changed = false;
   reports.forEach((report, i) => {
     if (!decisions[i].useCache) {
@@ -129,5 +136,5 @@ export async function getUsageForAccounts(accounts, options = {}) {
       // a cache write failure must not break the command
     }
   }
-  return reports;
+  return withEstimates;
 }

--- a/packages/usage/src/index.d.ts
+++ b/packages/usage/src/index.d.ts
@@ -41,6 +41,8 @@ type UsageWindow$5 = {
     resetsAt?: string;
     /** Share of the plan available to this model-specific window. */
     capPercent?: number;
+    /** True when this window is derived from a local signal, not the provider. */
+    estimate?: boolean;
 };
 
 /**
@@ -48,7 +50,7 @@ type UsageWindow$5 = {
  * utilization, API-key headers, local estimate — produces this same shape so the
  * CLI, gateway, and UI render one model.
  */
-type UsageReport$6 = {
+type UsageReport$7 = {
     /** The account's label in `~/.smithers/accounts.json`. */
     accountLabel: string;
     /** The account's provider. */
@@ -94,9 +96,9 @@ type UsageReport$6 = {
  * @param {Account} account
  * @returns {Promise<UsageReport>}
  */
-declare function getAccountUsage(account: Account$4): Promise<UsageReport$5>;
+declare function getAccountUsage(account: Account$4): Promise<UsageReport$6>;
 type Account$4 = _smthrs_accounts.Account;
-type UsageReport$5 = UsageReport$6;
+type UsageReport$6 = UsageReport$7;
 
 /**
  * Gathers usage for many accounts in parallel, served through the on-disk cache.
@@ -112,9 +114,9 @@ declare function getUsageForAccounts(accounts: Account$3[], options?: {
     bypassHardFloor?: boolean;
     env?: NodeJS.ProcessEnv;
     nowMs?: number;
-}): Promise<UsageReport$4[]>;
+}): Promise<UsageReport$5[]>;
 type Account$3 = _smthrs_accounts.Account;
-type UsageReport$4 = UsageReport$6;
+type UsageReport$5 = UsageReport$7;
 
 /** @typedef {import("@smthrs/accounts").Account} Account */
 /** @typedef {import("./UsageReport.ts").UsageReport} UsageReport */
@@ -142,9 +144,9 @@ type UsageReport$4 = UsageReport$6;
  */
 declare function buildUsageReport(account: Account$2, probe: UsageProbe$6, options?: {
     nowIso?: string;
-}): UsageReport$3;
+}): UsageReport$4;
 type Account$2 = _smthrs_accounts.Account;
-type UsageReport$3 = UsageReport$6;
+type UsageReport$4 = UsageReport$7;
 /**
  * The partial result an adapter returns. The dispatcher wraps it with the
  * account identity and timestamp to form a complete {@link UsageReport}.
@@ -170,8 +172,8 @@ type UsageProbe$6 = {
  * @param {number} [nowMs]
  * @returns {string}
  */
-declare function formatUsageReports(reports: UsageReport$2[], nowMs?: number): string;
-type UsageReport$2 = UsageReport$6;
+declare function formatUsageReports(reports: UsageReport$3[], nowMs?: number): string;
+type UsageReport$3 = UsageReport$7;
 
 /**
  * Formats an ISO reset timestamp as a relative "resets in" string. Returns an
@@ -197,6 +199,11 @@ declare function humanizeDurationShort(seconds: number): string;
  * Normalizes the Claude Code subscription usage payload into usage windows. The
  * payload powers the in-CLI `/usage` view: a 5-hour rolling window, a weekly
  * window, and optional per-model weekly windows.
+ *
+ * Per-model windows come from two shapes. Current payloads carry them in
+ * `limits[]` as `kind: "weekly_scoped"` entries with
+ * `scope.model.display_name` (for example "Fable"). Older payloads carried
+ * dedicated `seven_day_<model>` blocks. Both parse to the same window ids.
  *
  * @param {unknown} payload
  * @returns {UsageWindow[]}
@@ -499,6 +506,107 @@ declare function googleUsage(account: {
 }): Promise<UsageProbe>;
 type UsageProbe = UsageProbe$6;
 
+/** @param {NodeJS.ProcessEnv} [env] */
+declare function accountQuotaStatePath(env?: NodeJS.ProcessEnv): string;
+/**
+ * Read persisted account quota blocks. Expired and malformed entries are
+ * ignored so an old marker never disables an account permanently.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {number} [nowMs]
+ * @returns {{ version: 1; entries: Record<string, { untilMs: number; model?: string; observedAt: string }> }}
+ */
+declare function readAccountQuotaState$1(env?: NodeJS.ProcessEnv, nowMs?: number): {
+    version: 1;
+    entries: Record<string, {
+        untilMs: number;
+        model?: string;
+        observedAt: string;
+    }>;
+};
+/**
+ * Persist a provider-reported quota reset for an account. A short bounded TTL
+ * is used when the provider omits a reset, which prevents immediate hammering
+ * without permanently disabling the account.
+ *
+ * @param {string} label
+ * @param {{ untilMs?: number; model?: string; scope?: "shared" | "model"; nowMs?: number; env?: NodeJS.ProcessEnv }} [options]
+ */
+declare function recordAccountQuotaLimit(label: string, options?: {
+    untilMs?: number;
+    model?: string;
+    scope?: "shared" | "model";
+    nowMs?: number;
+    env?: NodeJS.ProcessEnv;
+}): {
+    untilMs: number;
+    model?: string;
+    observedAt: string;
+};
+/** @param {string} label @param {NodeJS.ProcessEnv} [env] */
+declare function clearAccountQuotaLimit(label: string, env?: NodeJS.ProcessEnv): boolean;
+/**
+ * Find the quota block that applies to a model. Shared blocks apply to every
+ * model. Fable, Opus, and Sonnet blocks apply only to their own family. When
+ * both apply, the later reset is when the account becomes usable.
+ *
+ * @param {ReturnType<typeof readAccountQuotaState>["entries"]} entries
+ * @param {string} label
+ * @param {string | undefined} model
+ * @param {UsageReport | undefined} [report]
+ * @param {number} [nowMs]
+ */
+declare function accountQuotaBlock(entries: ReturnType<typeof readAccountQuotaState$1>["entries"], label: string, model: string | undefined, report?: UsageReport$2 | undefined, nowMs?: number): {
+    untilMs: number;
+    model?: string;
+    observedAt: string;
+};
+/** @param {UsageReport | undefined} report @param {string | undefined} model */
+declare function accountUsageScore(report: UsageReport$2 | undefined, model: string | undefined): number;
+/**
+ * Order registered accounts from most headroom to least. Persisted quota-dead
+ * accounts sort last, with the soonest reset first. The caller can replace
+ * those rows with no-network quota sentinels instead of probing them again.
+ *
+ * @param {Account[]} accounts
+ * @param {{ env?: NodeJS.ProcessEnv; modelFor?: (account: Account) => string | undefined; nowMs?: number; tieBreak?: Map<string, number> }} [options]
+ */
+declare function orderAccountsByUsage(accounts: Account$1[], options?: {
+    env?: NodeJS.ProcessEnv;
+    modelFor?: (account: Account$1) => string | undefined;
+    nowMs?: number;
+    tieBreak?: Map<string, number>;
+}): {
+    label: string;
+    provider: "claude-code" | "antigravity" | "codex" | "kimi" | "anthropic-api" | "openai-api" | "gemini-api";
+    configDir?: string;
+    apiKey?: string;
+    model?: string;
+    addedAt?: string;
+}[];
+type Account$1 = _smthrs_accounts.Account;
+type UsageReport$2 = UsageReport$7;
+
+/** @typedef {import("./UsageReport.ts").UsageReport} UsageReport */
+/** @typedef {import("./UsageWindow.ts").UsageWindow} UsageWindow */
+/** @typedef {import("./accountSelection.js").readAccountQuotaState} readAccountQuotaState */
+/**
+ * Derives a best-effort Fable window from a persisted model-scoped quota
+ * event. The Claude usage endpoint does not always report a Fable window, but
+ * a recorded Fable rejection (`<label>::fable` in account-quota-state.json)
+ * still pinpoints the cap: the window is full until the recorded reset.
+ *
+ * The derived window is marked `unit: "estimated"` and `estimate: true` so
+ * renderers can distinguish it from provider-authoritative windows.
+ *
+ * @param {UsageReport} report
+ * @param {ReturnType<typeof readAccountQuotaState>["entries"]} entries Quota-state entries, already filtered to unexpired rows.
+ * @returns {UsageReport}
+ */
+declare function withFableQuotaEstimate(report: UsageReport$1, entries: ReturnType<typeof readAccountQuotaState>["entries"]): UsageReport$1;
+type UsageReport$1 = UsageReport$7;
+type readAccountQuotaState = typeof readAccountQuotaState$1;
+
 /**
  * Looks up a published cap by tier id. Returns `undefined` for unknown tiers so
  * the caller can degrade to "unknown" rather than invent a number.
@@ -556,10 +664,10 @@ declare function readUsageCache(env?: NodeJS.ProcessEnv): UsageCacheFile;
 declare function writeUsageCache(contents: UsageCacheFile, env?: NodeJS.ProcessEnv): string;
 /** @param {string} label @param {NodeJS.ProcessEnv} [env] */
 declare function clearAccountUsageCache(label: string, env?: NodeJS.ProcessEnv): boolean;
-type UsageReport$1 = UsageReport$6;
-type Account$1 = _smthrs_accounts.Account;
+type UsageReport = UsageReport$7;
+type Account = _smthrs_accounts.Account;
 type UsageCacheAccountIdentity = {
-    provider: Account$1["provider"];
+    provider: Account["provider"];
     configDir?: string;
     model?: string;
     apiKeyHash?: string;
@@ -569,89 +677,8 @@ type UsageCacheFile = {
     version: 1;
     entries: Record<string, {
         identity?: UsageCacheAccountIdentity;
-        report: UsageReport$1;
+        report: UsageReport;
     }>;
 };
 
-/** @param {NodeJS.ProcessEnv} [env] */
-declare function accountQuotaStatePath(env?: NodeJS.ProcessEnv): string;
-/**
- * Read persisted account quota blocks. Expired and malformed entries are
- * ignored so an old marker never disables an account permanently.
- *
- * @param {NodeJS.ProcessEnv} [env]
- * @param {number} [nowMs]
- * @returns {{ version: 1; entries: Record<string, { untilMs: number; model?: string; observedAt: string }> }}
- */
-declare function readAccountQuotaState(env?: NodeJS.ProcessEnv, nowMs?: number): {
-    version: 1;
-    entries: Record<string, {
-        untilMs: number;
-        model?: string;
-        observedAt: string;
-    }>;
-};
-/**
- * Persist a provider-reported quota reset for an account. A short bounded TTL
- * is used when the provider omits a reset, which prevents immediate hammering
- * without permanently disabling the account.
- *
- * @param {string} label
- * @param {{ untilMs?: number; model?: string; scope?: "shared" | "model"; nowMs?: number; env?: NodeJS.ProcessEnv }} [options]
- */
-declare function recordAccountQuotaLimit(label: string, options?: {
-    untilMs?: number;
-    model?: string;
-    scope?: "shared" | "model";
-    nowMs?: number;
-    env?: NodeJS.ProcessEnv;
-}): {
-    untilMs: number;
-    model?: string;
-    observedAt: string;
-};
-/** @param {string} label @param {NodeJS.ProcessEnv} [env] */
-declare function clearAccountQuotaLimit(label: string, env?: NodeJS.ProcessEnv): boolean;
-/**
- * Find the quota block that applies to a model. Shared blocks apply to every
- * model. Fable, Opus, and Sonnet blocks apply only to their own family. When
- * both apply, the later reset is when the account becomes usable.
- *
- * @param {ReturnType<typeof readAccountQuotaState>["entries"]} entries
- * @param {string} label
- * @param {string | undefined} model
- * @param {UsageReport | undefined} [report]
- * @param {number} [nowMs]
- */
-declare function accountQuotaBlock(entries: ReturnType<typeof readAccountQuotaState>["entries"], label: string, model: string | undefined, report?: UsageReport | undefined, nowMs?: number): {
-    untilMs: number;
-    model?: string;
-    observedAt: string;
-};
-/** @param {UsageReport | undefined} report @param {string | undefined} model */
-declare function accountUsageScore(report: UsageReport | undefined, model: string | undefined): number;
-/**
- * Order registered accounts from most headroom to least. Persisted quota-dead
- * accounts sort last, with the soonest reset first. The caller can replace
- * those rows with no-network quota sentinels instead of probing them again.
- *
- * @param {Account[]} accounts
- * @param {{ env?: NodeJS.ProcessEnv; modelFor?: (account: Account) => string | undefined; nowMs?: number; tieBreak?: Map<string, number> }} [options]
- */
-declare function orderAccountsByUsage(accounts: Account[], options?: {
-    env?: NodeJS.ProcessEnv;
-    modelFor?: (account: Account) => string | undefined;
-    nowMs?: number;
-    tieBreak?: Map<string, number>;
-}): {
-    label: string;
-    provider: "claude-code" | "antigravity" | "codex" | "kimi" | "anthropic-api" | "openai-api" | "gemini-api";
-    configDir?: string;
-    apiKey?: string;
-    model?: string;
-    addedAt?: string;
-}[];
-type Account = _smthrs_accounts.Account;
-type UsageReport = UsageReport$6;
-
-export { PUBLISHED_CAPS, type UsageReport$6 as UsageReport, type UsageWindow$5 as UsageWindow, accountQuotaBlock, accountQuotaStatePath, accountUsageScore, anthropicHeaderUsage, buildUsageReport, claudeKeychainSuffix, claudeOauthUsage, clearAccountQuotaLimit, clearAccountUsageCache, codexWhamUsage, decodeJwtClaims, formatRelativeReset, formatUsageReports, getAccountUsage, getUsageForAccounts, googleUsage, humanizeDurationShort, kimiCodeUsage, openaiHeaderUsage, orderAccountsByUsage, parseAnthropicRateLimitHeaders, parseClaudeOauthUsage, parseCodexUsage, parseDurationSeconds, parseKimiUsage, parseOpenAiRateLimitHeaders, publishedCapForTier, readAccountQuotaState, readClaudeCredentials, readCodexCredentials, readKimiCredentials, readUsageCache, recordAccountQuotaLimit, refreshKimiToken, usageCachePath, writeUsageCache };
+export { PUBLISHED_CAPS, type UsageReport$7 as UsageReport, type UsageWindow$5 as UsageWindow, accountQuotaBlock, accountQuotaStatePath, accountUsageScore, anthropicHeaderUsage, buildUsageReport, claudeKeychainSuffix, claudeOauthUsage, clearAccountQuotaLimit, clearAccountUsageCache, codexWhamUsage, decodeJwtClaims, formatRelativeReset, formatUsageReports, getAccountUsage, getUsageForAccounts, googleUsage, humanizeDurationShort, kimiCodeUsage, openaiHeaderUsage, orderAccountsByUsage, parseAnthropicRateLimitHeaders, parseClaudeOauthUsage, parseCodexUsage, parseDurationSeconds, parseKimiUsage, parseOpenAiRateLimitHeaders, publishedCapForTier, readAccountQuotaState$1 as readAccountQuotaState, readClaudeCredentials, readCodexCredentials, readKimiCredentials, readUsageCache, recordAccountQuotaLimit, refreshKimiToken, usageCachePath, withFableQuotaEstimate, writeUsageCache };

--- a/packages/usage/src/index.js
+++ b/packages/usage/src/index.js
@@ -32,3 +32,4 @@ export {
   accountQuotaBlock,
   orderAccountsByUsage,
 } from "./accountSelection.js";
+export { withFableQuotaEstimate } from "./fableQuotaEstimate.js";

--- a/packages/usage/src/parseClaudeOauthUsage.js
+++ b/packages/usage/src/parseClaudeOauthUsage.js
@@ -24,9 +24,71 @@ function windowFrom(block, id, label) {
 }
 
 /**
+ * Labels and plan-cap metadata for known per-model weekly windows, keyed by
+ * the lowercased model display name the endpoint reports.
+ *
+ * @type {Record<string, { id: string; label: string; capPercent?: number }>}
+ */
+const MODEL_WINDOWS = {
+  opus: { id: "weekly-opus", label: "weekly (Opus)" },
+  sonnet: { id: "weekly-sonnet", label: "weekly (Sonnet)" },
+  fable: { id: "weekly-fable", label: "weekly (Fable, 50% plan cap)", capPercent: 50 },
+};
+
+/**
+ * Reads the model display name out of a `limits[]` entry scope.
+ *
+ * @param {unknown} scope
+ * @returns {string | undefined}
+ */
+function scopedModelName(scope) {
+  if (!scope || typeof scope !== "object") return undefined;
+  const model = /** @type {{ model?: unknown }} */ (scope).model;
+  if (!model || typeof model !== "object") return undefined;
+  const name = /** @type {{ display_name?: unknown }} */ (model).display_name;
+  return typeof name === "string" && name.length > 0 ? name : undefined;
+}
+
+/**
+ * Builds one percent window from a `limits[]` entry as returned by
+ * `GET https://api.anthropic.com/api/oauth/usage`. Entries use
+ * `{ kind, percent, resets_at, scope }` instead of the
+ * `{ utilization, resets_at }` shape of the top-level blocks.
+ *
+ * @param {unknown} entry
+ * @returns {{ id: string; window: UsageWindow } | undefined}
+ */
+function windowFromLimit(entry) {
+  if (!entry || typeof entry !== "object") return undefined;
+  const e = /** @type {Record<string, unknown>} */ (entry);
+  if (e.kind !== "weekly_scoped") return undefined;
+  const name = scopedModelName(e.scope);
+  if (!name) return undefined;
+  if (typeof e.percent !== "number") return undefined;
+  const known = MODEL_WINDOWS[name.toLowerCase()];
+  const id = known?.id ?? `weekly-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  const label = known?.label ?? `weekly (${name})`;
+  /** @type {UsageWindow} */
+  const window = {
+    id,
+    label,
+    unit: "percent",
+    usedPercent: e.percent,
+    resetsAt: typeof e.resets_at === "string" ? e.resets_at : undefined,
+  };
+  if (known?.capPercent !== undefined) window.capPercent = known.capPercent;
+  return { id, window };
+}
+
+/**
  * Normalizes the Claude Code subscription usage payload into usage windows. The
  * payload powers the in-CLI `/usage` view: a 5-hour rolling window, a weekly
  * window, and optional per-model weekly windows.
+ *
+ * Per-model windows come from two shapes. Current payloads carry them in
+ * `limits[]` as `kind: "weekly_scoped"` entries with
+ * `scope.model.display_name` (for example "Fable"). Older payloads carried
+ * dedicated `seven_day_<model>` blocks. Both parse to the same window ids.
  *
  * @param {unknown} payload
  * @returns {UsageWindow[]}
@@ -47,6 +109,12 @@ export function parseClaudeOauthUsage(payload) {
   if (fable) {
     fable.capPercent = 50;
     windows.push(fable);
+  }
+  if (Array.isArray(p.limits)) {
+    for (const entry of p.limits) {
+      const parsed = windowFromLimit(entry);
+      if (parsed && !windows.some((w) => w.id === parsed.id)) windows.push(parsed.window);
+    }
   }
   return windows;
 }

--- a/packages/usage/tests/usage-coverage.test.js
+++ b/packages/usage/tests/usage-coverage.test.js
@@ -30,6 +30,7 @@ import {
   readKimiCredentials,
   refreshKimiToken,
   recordAccountQuotaLimit,
+  withFableQuotaEstimate,
   writeUsageCache,
 } from "../src/index.js";
 
@@ -1028,6 +1029,30 @@ describe("quota-aware account selection", () => {
     expect(Object.keys(readAccountQuotaState(env, 0).entries)).toEqual([]);
   });
 
+  test("fable-capped account sorts last for fable pools and normally for opus pools", () => {
+    const env = { SMITHERS_HOME: tempDir() };
+    const nowMs = Date.parse("2026-08-15T00:00:00Z");
+    recordAccountQuotaLimit("capped", {
+      env,
+      nowMs,
+      untilMs: nowMs + 3_600_000,
+      model: "claude-fable-5",
+      scope: "model",
+    });
+    const accounts = [
+      { label: "healthy", provider: "claude-code", configDir: "/healthy" },
+      { label: "capped", provider: "claude-code", configDir: "/capped" },
+    ];
+    expect(
+      orderAccountsByUsage(accounts, { env, nowMs, modelFor: () => "claude-fable-5" }).map((row) => row.label),
+    ).toEqual(["healthy", "capped"]);
+    // The model-scoped block does not apply to Opus, so neither account is
+    // penalized and the label tie-break puts "capped" first.
+    expect(
+      orderAccountsByUsage(accounts, { env, nowMs, modelFor: () => "claude-opus-5" }).map((row) => row.label),
+    ).toEqual(["capped", "healthy"]);
+  });
+
   test("treats exhausted cached model usage as blocked until its reset", () => {
     const nowMs = Date.parse("2026-08-15T00:00:00Z");
     const resetAt = "2026-08-15T01:00:00Z";
@@ -1050,6 +1075,79 @@ describe("quota-aware account selection", () => {
     });
     expect(accountQuotaBlock({}, "a", "claude-opus-5", report, nowMs)).toBeUndefined();
     expect(accountQuotaBlock({}, "a", "claude-fable-5", report, Date.parse(resetAt) + 1)).toBeUndefined();
+  });
+});
+
+describe("fable quota estimate", () => {
+  const baseReport = {
+    accountLabel: "cl",
+    provider: "claude-code",
+    authMode: "subscription",
+    source: "oauth",
+    stale: false,
+    estimate: false,
+    fetchedAt: "2026-08-15T00:00:00Z",
+    windows: [{ id: "weekly", label: "weekly", unit: "percent", usedPercent: 40 }],
+  };
+
+  test("derives an estimated Fable window from a persisted fable quota event", () => {
+    const untilMs = Date.parse("2026-08-15T01:00:00Z");
+    const report = withFableQuotaEstimate(baseReport, {
+      "cl::fable": { untilMs, model: "claude-fable-5", observedAt: "2026-08-15T00:00:00Z" },
+    });
+    expect(report.windows).toHaveLength(2);
+    expect(report.windows[1]).toEqual({
+      id: "weekly-fable",
+      label: "weekly (Fable, 50% plan cap)",
+      unit: "estimated",
+      usedPercent: 100,
+      resetsAt: "2026-08-15T01:00:00.000Z",
+      capPercent: 50,
+      estimate: true,
+    });
+  });
+
+  test("does not estimate over a provider-reported Fable window or for other providers", () => {
+    const entries = {
+      "cl::fable": { untilMs: Date.parse("2026-08-15T01:00:00Z"), observedAt: "2026-08-15T00:00:00Z" },
+    };
+    const withFable = {
+      ...baseReport,
+      windows: [
+        ...baseReport.windows,
+        { id: "weekly-fable", label: "weekly (Fable, 50% plan cap)", unit: "percent", usedPercent: 12 },
+      ],
+    };
+    expect(withFableQuotaEstimate(withFable, entries)).toBe(withFable);
+    const codex = { ...baseReport, provider: "codex" };
+    expect(withFableQuotaEstimate(codex, entries)).toBe(codex);
+    expect(withFableQuotaEstimate(baseReport, {})).toBe(baseReport);
+  });
+
+  test("getUsageForAccounts surfaces the estimate as a ~100% (est) row", async () => {
+    const env = { SMITHERS_HOME: tempDir() };
+    const nowMs = Date.parse("2026-08-15T00:00:00Z");
+    recordAccountQuotaLimit("cl", {
+      env,
+      nowMs,
+      untilMs: nowMs + 3_600_000,
+      model: "claude-fable-5",
+      scope: "model",
+    });
+    // No credentials on disk: the probe degrades to `none`, but the persisted
+    // Fable rejection still yields an estimated meter.
+    const [report] = await getUsageForAccounts([{ label: "cl", provider: "claude-code", configDir: "/missing" }], {
+      env,
+      nowMs,
+    });
+    const fable = report.windows.find((window) => window.id === "weekly-fable");
+    expect(fable).toMatchObject({
+      unit: "estimated",
+      usedPercent: 100,
+      estimate: true,
+      resetsAt: new Date(nowMs + 3_600_000).toISOString(),
+    });
+    expect(formatUsageReports([report], nowMs)).toContain("~100% (est)");
   });
 });
 

--- a/packages/usage/tests/usage.test.js
+++ b/packages/usage/tests/usage.test.js
@@ -107,6 +107,82 @@ describe("parseClaudeOauthUsage", () => {
       capPercent: 50,
     });
   });
+  test("parses the limits[] model-scoped window (current endpoint shape)", () => {
+    // Captured 2026-08-16 from GET /api/oauth/usage on a Max account that had
+    // hit the Fable cap. There is no seven_day_fable field; the Fable window
+    // only appears as a weekly_scoped limits[] entry.
+    const windows = parseClaudeOauthUsage({
+      five_hour: { utilization: 7, resets_at: "2026-08-16T17:59:59.765937+00:00" },
+      seven_day: { utilization: 53, resets_at: "2026-08-18T21:59:59.765981+00:00" },
+      seven_day_opus: null,
+      seven_day_sonnet: null,
+      limits: [
+        {
+          kind: "session",
+          group: "session",
+          percent: 7,
+          severity: "normal",
+          resets_at: "2026-08-16T17:59:59.765937+00:00",
+          scope: null,
+          is_active: false,
+        },
+        {
+          kind: "weekly_all",
+          group: "weekly",
+          percent: 53,
+          severity: "normal",
+          resets_at: "2026-08-18T21:59:59.765981+00:00",
+          scope: null,
+          is_active: false,
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 100,
+          severity: "critical",
+          resets_at: "2026-08-18T21:59:59.766338+00:00",
+          scope: { model: { id: null, display_name: "Fable" }, surface: null },
+          is_active: true,
+        },
+      ],
+    });
+    expect(windows.map((w) => w.id)).toEqual(["5h", "weekly", "weekly-fable"]);
+    expect(windows[2]).toMatchObject({
+      label: "weekly (Fable, 50% plan cap)",
+      unit: "percent",
+      usedPercent: 100,
+      resetsAt: "2026-08-18T21:59:59.766338+00:00",
+      capPercent: 50,
+    });
+  });
+  test("maps other limits[] model scopes and dedupes against seven_day_* blocks", () => {
+    const windows = parseClaudeOauthUsage({
+      seven_day_opus: { utilization: 5, resets_at: isoIn(86400) },
+      limits: [
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 40,
+          resets_at: isoIn(86400),
+          scope: { model: { id: null, display_name: "Opus" }, surface: null },
+          is_active: false,
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 12,
+          resets_at: isoIn(86400),
+          scope: { model: { id: null, display_name: "Sonnet" }, surface: null },
+          is_active: false,
+        },
+      ],
+    });
+    // The dedicated seven_day_opus block wins over the limits[] duplicate.
+    expect(windows).toEqual([
+      { id: "weekly-opus", label: "weekly (Opus)", unit: "percent", usedPercent: 5, resetsAt: isoIn(86400) },
+      { id: "weekly-sonnet", label: "weekly (Sonnet)", unit: "percent", usedPercent: 12, resetsAt: isoIn(86400) },
+    ]);
+  });
   test("tolerates junk", () => {
     expect(parseClaudeOauthUsage(null)).toEqual([]);
     expect(parseClaudeOauthUsage({ five_hour: { utilization: "x" } })).toEqual([]);

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -19285,9 +19285,14 @@ The result names each signed-in subscription and warns when labels share one
 Anthropic organization and quota.
 
 `bunx smthrs usage --fresh` shows the 5-hour, weekly, Opus, Sonnet, and Fable
-windows that the provider returns. Fable has a 50% weekly plan cap. Smithers
-normalizes the shared weekly value against that cap when the provider omits a
-dedicated Fable window.
+windows that the provider returns. The Claude usage endpoint reports per-model
+windows as model-scoped weekly limit entries (`limits[]` with
+`kind: "weekly_scoped"` and `scope.model.display_name`), not as dedicated
+payload fields. Fable has a 50% weekly plan cap. When the provider omits the
+Fable window but Smithers has recorded a Fable rejection for the account,
+`usage` derives a best-effort Fable window from that event and marks it as an
+estimate (`~100% (est)`) until the recorded reset. The quota dashboard renders
+the Fable window as its own per-account meter labeled "Fable (50% cap)".
 
 ### Multi-account Claude pool
 
@@ -19315,10 +19320,12 @@ import { fallbackAgents } from "smthrs";
 
 Copy every permission, sandbox, and tool option from the old
 `ClaudeCodeAgent` into `agentOptions["claude-code"]`. Smithers orders healthy
-accounts by model-specific headroom. It persists provider reset times and
-skips known rate-limited accounts without starting Claude again. A cached
-window at 100% also blocks the account until its reported reset. The run seed
-keeps every account at the same chain index after quota state changes.
+accounts by model-specific headroom: a Fable pool sorts by Fable-window
+headroom, while an Opus or Sonnet pool ignores the Fable window. It persists
+provider reset times and skips known rate-limited accounts without starting
+Claude again. A cached window at 100% also blocks the account until its
+reported reset. The run seed keeps every account at the same chain index
+after quota state changes.
 
 The example excludes the ambient `~/.claude` login because `fallback: []`
 disables the default tail. Omit that line to keep the ambient login as the


### PR DESCRIPTION
## What

Anthropic Max plans cap Fable 5 at 50% of the weekly plan limit. Probing live accounts shows the Claude OAuth usage endpoint (`GET /api/oauth/usage`) does **not** expose a `seven_day_fable` field. The Fable window appears only in the `limits[]` array as:

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 100,
  "severity": "critical",
  "resets_at": "2026-08-18T21:59:59.766338+00:00",
  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
  "is_active": true
}
```

## Changes

- **`packages/usage/src/parseClaudeOauthUsage.js`** — parse `limits[]` `weekly_scoped` entries into per-model weekly windows (`weekly-fable` with `capPercent: 50`, `weekly-opus`, `weekly-sonnet`). Legacy `seven_day_<model>` blocks still parse and take precedence on id collisions.
- **`packages/usage/src/fableQuotaEstimate.js`** (new) — `withFableQuotaEstimate` derives a best-effort Fable window from a persisted `<label>::fable` quota event when the endpoint omits the window. The window is marked `unit: "estimated"` and `estimate: true`; `smithers usage` renders it as `~100% (est)`. Wired into `getUsageForAccounts`; raw reports stay in the cache unmodified.
- **Account selection** — Fable-aware ordering landed in #1571 (`accountUsageScore`/`accountQuotaBlock` already key on `weekly-fable`); this PR adds the missing ordering test: a Fable-capped account sorts last for Fable pools and is unpenalized for Opus pools.
- **`apps/quota-dashboard`** — each seat renders a third meter, "Fable (50% cap)", including an "estimated" marker for derived windows.
- **Docs** — `docs/integrations/cli-agents.mdx` describes the real endpoint shape, the estimate fallback, and the model-specific ordering; llms bundles regenerated.

## Verified

- Real probes of claude-1/2/4 (verbatim field names above): `five_hour`, `seven_day`, `limits[].kind/percent/resets_at/scope.model.display_name`. No `seven_day_fable` exists in the live payload.
- `smithers usage --fresh` from this tree prints a per-account `weekly (Fable, 50% plan cap)` row alongside 5-hour and weekly (claude-2/4/5/7 show 100% — capped; claude-1/3/6 show 71–84%).
- `pnpm -C packages/usage test` (79 pass), `pnpm typecheck`, `pnpm lint`, `pnpm check:docs`, `pnpm check:llms`, `pnpm check:dts` all green. The 4 NanocodexAgent failures in `packages/agents` reproduce on a clean origin/main checkout and are unrelated.

## New `smithers usage` row shape

```
claude-2  claude-code  willcory10@proton.me  max  weekly (Fable, 50% plan cap)  100%  13h 9m
```

Estimated fallback (no provider Fable window, recorded rejection):

```
claude-9  claude-code  …  max  weekly (Fable, 50% plan cap)  ~100% (est)  59m 12s
```