### PR TITLE
🐛 fix(engine): stop a dead resume session from consuming retry budget

### DIFF
--- a/packages/agents/tests/classifySessionLoss.test.js
+++ b/packages/agents/tests/classifySessionLoss.test.js
@@ -83,6 +83,33 @@ describe("classifySessionLoss", () => {
     expect(err.message).not.toContain("Retry will start a fresh session");
   });
 
+  test("claude crash on a FRESH session is flagged so it counts as an agent failure, not a fixable resume", () => {
+    const err = classifySessionLoss(
+      "claude",
+      "No conversation found with session ID: 68b187d0-a325-4384-a248-b2a0e6edbd90",
+      "",
+      false,
+    );
+    expect(err).not.toBeNull();
+    expect(err.code).toBe("AGENT_SESSION_LOST");
+    expect(err.details.freshSessionFailure).toBe(true);
+    // Still discard the broken id: the heartbeat may have captured it.
+    expect(err.details.discardResumeSession).toBe(true);
+    expect(err.message).toContain("FRESH session");
+    expect(err.message).not.toContain("Retry will start a fresh session");
+  });
+
+  test("a resumed claude session is flagged as recoverable so it does not consume retry budget", () => {
+    const err = classifySessionLoss(
+      "claude",
+      "No conversation found with session ID: 68b187d0-a325-4384-a248-b2a0e6edbd90",
+      "",
+      true,
+    );
+    expect(err.details.freshSessionFailure).toBe(false);
+    expect(err.message).toContain("Retry will start a fresh session");
+  });
+
   test("the claude pattern on a different CLI is NOT session loss", () => {
     expect(classifySessionLoss("codex", "No conversation found with session ID: abc12345", "")).toBeNull();
   });

--- a/packages/engine/src/effect/isDiscardedSessionAttempt.js
+++ b/packages/engine/src/effect/isDiscardedSessionAttempt.js
@@ -1,0 +1,41 @@
+/**
+ * A resumed agent session whose persisted id is dead fails the attempt before
+ * any work is dispatched: the agent discards the id and the next attempt opens
+ * a fresh session. Like a quota-limited attempt, such a failure must never
+ * consume the task's retry budget — otherwise a long task whose session ids go
+ * stale (the CLI pruned the conversation, the machine restarted, the id aged
+ * out) exhausts its budget on session bookkeeping instead of real failures.
+ *
+ * A session that broke even though the attempt started FRESH is deliberately
+ * excluded: retrying cannot help, so it must consume the budget and let the
+ * task fail over to the next agent in the chain.
+ *
+ * @param {{ errorJson?: string | null; metaJson?: string | null } | null} [attempt]
+ * @returns {boolean}
+ */
+export function isDiscardedSessionAttempt(attempt) {
+  if (!attempt) return false;
+  if (attempt.errorJson) {
+    try {
+      const error = JSON.parse(attempt.errorJson);
+      if (error?.code === "AGENT_SESSION_LOST" && isDiscardedResumeDetails(error?.details)) return true;
+    } catch {
+      // A malformed failure payload cannot prove the session was discarded.
+    }
+  }
+  if (attempt.metaJson) {
+    try {
+      return isDiscardedResumeDetails(JSON.parse(attempt.metaJson));
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/** @param {unknown} details */
+function isDiscardedResumeDetails(details) {
+  if (!details || typeof details !== "object" || Array.isArray(details)) return false;
+  const typed = /** @type {{ discardResumeSession?: unknown; freshSessionFailure?: unknown }} */ (details);
+  return typed.discardResumeSession === true && typed.freshSessionFailure !== true;
+}

--- a/packages/engine/src/effect/retry-state.js
+++ b/packages/engine/src/effect/retry-state.js
@@ -1,4 +1,5 @@
 import { createDurableRetryState, isRetryableFailure } from "@smthrs/scheduler";
+import { isDiscardedSessionAttempt } from "./isDiscardedSessionAttempt.js";
 
 export const RETRY_STATE_META_KEY = "retryState";
 
@@ -56,7 +57,9 @@ function retryAfterMs(error) {
 export function stampDurableRetryState(input) {
   if (isQuotaFailurePayload(input.error)) return null;
   const failureCount =
-    input.attempts.filter((attempt) => attempt.state === "failed" && !isQuotaAttempt(attempt)).length + 1;
+    input.attempts.filter(
+      (attempt) => attempt.state === "failed" && !isQuotaAttempt(attempt) && !isDiscardedSessionAttempt(attempt),
+    ).length + 1;
   const code = typeof input.error.code === "string" ? input.error.code : null;
   const kind = typeof input.attemptMeta.kind === "string" ? input.attemptMeta.kind : null;
   const retryable =

--- a/packages/engine/src/effect/workflow-bridge.js
+++ b/packages/engine/src/effect/workflow-bridge.js
@@ -12,6 +12,7 @@ import { isRetryableFailure } from "@smthrs/scheduler";
 import { makeWorkerTask } from "./entity-worker.js";
 import { executeTaskActivity, makeTaskBridgeKey, RetriableTaskFailure } from "./activity-bridge.js";
 import { parseAttemptMetaJson } from "./bridge-utils.js";
+import { isDiscardedSessionAttempt } from "./isDiscardedSessionAttempt.js";
 import { canExecuteBridgeManagedComputeTask, executeComputeTaskBridge } from "./compute-task-bridge.js";
 import { canExecuteBridgeManagedStaticTask, executeStaticTaskBridge } from "./static-task-bridge.js";
 import { dispatchWorkerTask } from "./single-runner.js";
@@ -193,7 +194,9 @@ const classifyTaskAttempt = async (adapter, runId, desc, context) => {
   if (latestState === "failed") {
     const failedAttempts = attempts.filter((attempt) => attempt.state === "failed");
     const hasNonRetryableFailure = failedAttempts.some((attempt) => !isRetryableBridgeTaskFailure(attempt, desc));
-    const retryConsumingFailures = failedAttempts.filter((attempt) => !isQuotaBridgeTaskFailure(attempt));
+    const retryConsumingFailures = failedAttempts.filter(
+      (attempt) => !isQuotaBridgeTaskFailure(attempt) && !isDiscardedSessionAttempt(attempt),
+    );
     if (
       !hasNonRetryableFailure &&
       (isQuotaBridgeTaskFailure(latest) || retryConsumingFailures.length <= desc.retries)

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -121,6 +121,7 @@ import { attachSandboxComputeFns, attachSubflowComputeFns, getSubflowChildRunId 
 import { SUBFLOW_RUN_LINEAGE_MAX_ROWS, subflowRunLineage } from "@smthrs/graph/subflow-run-lineage";
 import { buildCacheScopeIdentity, isFreshCacheRow, normalizeCacheScope } from "./cache-policy.js";
 import { RETRY_STATE_META_KEY, stampDurableRetryState } from "./effect/retry-state.js";
+import { isDiscardedSessionAttempt } from "./effect/isDiscardedSessionAttempt.js";
 import { runWorkflowWithMakeBridge } from "./effect/workflow-make-bridge.js";
 import {
   createWorkflowVersioningRuntime,
@@ -3979,7 +3980,9 @@ function retrySessionStateFromAttempts(attempts) {
   const retryWait = new Map();
   const taskFailures = new Map();
   for (const [key, rows] of byTask) {
-    const failed = rows.filter((attempt) => attempt.state === "failed" && !isQuotaTaskFailure(attempt));
+    const failed = rows.filter(
+      (attempt) => attempt.state === "failed" && !isQuotaTaskFailure(attempt) && !isDiscardedSessionAttempt(attempt),
+    );
     const latest = rows.reduce((candidate, attempt) => {
       if (!candidate) return attempt;
       const startedDelta = Number(attempt.startedAtMs ?? 0) - Number(candidate.startedAtMs ?? 0);
@@ -8783,7 +8786,9 @@ async function legacyExecuteTask(
     const updatedAttempts = await Effect.runPromise(adapter.listAttempts(runId, desc.nodeId, desc.iteration));
     const failedAttempts = updatedAttempts.filter((a) => a.state === "failed");
     const hasNonRetryableFailure = failedAttempts.some((attempt) => !isRetryableTaskFailure(attempt));
-    const retryConsumingFailedAttempts = failedAttempts.filter((a) => !isQuotaTaskFailure(a));
+    const retryConsumingFailedAttempts = failedAttempts.filter(
+      (a) => !isQuotaTaskFailure(a) && !isDiscardedSessionAttempt(a),
+    );
     const latestFailedAttemptIsQuota = isQuotaTaskFailure(failedAttempts[0]);
     if (
       !stalledVerdict &&
@@ -10223,7 +10228,9 @@ async function runWorkflowBodyDriver(workflow, opts) {
         const attempts = await Effect.runPromise(adapter.listAttempts(runId, task.nodeId, task.iteration));
         const failedAttempts = attempts.filter((attempt) => attempt.state === "failed");
         const hasNonRetryableFailure = failedAttempts.some((attempt) => !isRetryableTaskFailure(attempt));
-        const retryConsumingFailedAttempts = failedAttempts.filter((attempt) => !isQuotaTaskFailure(attempt));
+        const retryConsumingFailedAttempts = failedAttempts.filter(
+          (attempt) => !isQuotaTaskFailure(attempt) && !isDiscardedSessionAttempt(attempt),
+        );
         const latestFailedAttemptIsQuota = isQuotaTaskFailure(failedAttempts[0]);
         if (
           !latestFailedAttemptIsQuota &&

--- a/packages/engine/tests/discarded-session-retry-budget.test.js
+++ b/packages/engine/tests/discarded-session-retry-budget.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isDiscardedSessionAttempt } from "../src/effect/isDiscardedSessionAttempt.js";
 import { stampDurableRetryState } from "../src/effect/retry-state.js";
-import { classifySessionLoss } from "@smthrs/agents/BaseCliAgent/BaseCliAgent";
 
 /** @param {Record<string, unknown>} details */
 function sessionLostAttempt(details = { discardResumeSession: true, command: "claude" }) {
@@ -46,7 +45,13 @@ describe("isDiscardedSessionAttempt", () => {
   });
 
   test("reads the flag from attempt meta when the error carries no details", () => {
-    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: null, metaJson: JSON.stringify({ discardResumeSession: true }) })).toBe(true);
+    expect(
+      isDiscardedSessionAttempt({
+        state: "failed",
+        errorJson: null,
+        metaJson: JSON.stringify({ discardResumeSession: true }),
+      }),
+    ).toBe(true);
     expect(
       isDiscardedSessionAttempt({
         state: "failed",
@@ -59,7 +64,9 @@ describe("isDiscardedSessionAttempt", () => {
   test("ordinary, quota, and malformed failures are untouched", () => {
     expect(isDiscardedSessionAttempt(realFailureAttempt())).toBe(false);
     expect(isDiscardedSessionAttempt(quotaAttempt())).toBe(false);
-    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: "{not json", metaJson: "{also not json" })).toBe(false);
+    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: "{not json", metaJson: "{also not json" })).toBe(
+      false,
+    );
     expect(isDiscardedSessionAttempt(null)).toBe(false);
     expect(isDiscardedSessionAttempt(undefined)).toBe(false);
   });
@@ -91,22 +98,5 @@ describe("stampDurableRetryState budget accounting", () => {
 
   test("real failures still exhaust the budget", () => {
     expect(stamp([realFailureAttempt(), realFailureAttempt(), realFailureAttempt()])).toBeNull();
-  });
-});
-
-describe("classifySessionLoss marks fresh-session failures", () => {
-  const stderr = "No conversation found with session ID: 68b187d0-a325-4384-a248-b2a0e6edbd90";
-
-  test("a resumed claude session is retryable bookkeeping", () => {
-    const error = classifySessionLoss("claude", stderr, stderr, true);
-    expect(error?.details?.discardResumeSession).toBe(true);
-    expect(error?.details?.freshSessionFailure).toBe(false);
-    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: JSON.stringify(error), metaJson: null })).toBe(true);
-  });
-
-  test("a fresh claude session failure consumes the budget so the chain fails over", () => {
-    const error = classifySessionLoss("claude", stderr, stderr, false);
-    expect(error?.details?.freshSessionFailure).toBe(true);
-    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: JSON.stringify(error), metaJson: null })).toBe(false);
   });
 });

--- a/packages/engine/tests/discarded-session-retry-budget.test.js
+++ b/packages/engine/tests/discarded-session-retry-budget.test.js
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { isDiscardedSessionAttempt } from "../src/effect/isDiscardedSessionAttempt.js";
+import { stampDurableRetryState } from "../src/effect/retry-state.js";
+import { classifySessionLoss } from "@smthrs/agents/BaseCliAgent/BaseCliAgent";
+
+/** @param {Record<string, unknown>} details */
+function sessionLostAttempt(details = { discardResumeSession: true, command: "claude" }) {
+  return {
+    state: "failed",
+    errorJson: JSON.stringify({
+      code: "AGENT_SESSION_LOST",
+      message: "conversation no longer exists",
+      details,
+    }),
+    metaJson: null,
+  };
+}
+
+function quotaAttempt() {
+  return {
+    state: "failed",
+    errorJson: JSON.stringify({ code: "AGENT_QUOTA_EXCEEDED", message: "limit" }),
+    metaJson: null,
+  };
+}
+
+function realFailureAttempt() {
+  return {
+    state: "failed",
+    errorJson: JSON.stringify({ code: "AGENT_CLI_ERROR", message: "boom" }),
+    metaJson: null,
+  };
+}
+
+describe("isDiscardedSessionAttempt", () => {
+  test("a dead resume session is bookkeeping, not a consumed retry", () => {
+    expect(isDiscardedSessionAttempt(sessionLostAttempt())).toBe(true);
+  });
+
+  test("a session that broke on a FRESH start still consumes the budget", () => {
+    expect(
+      isDiscardedSessionAttempt(
+        sessionLostAttempt({ discardResumeSession: true, freshSessionFailure: true, command: "kimi" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("reads the flag from attempt meta when the error carries no details", () => {
+    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: null, metaJson: JSON.stringify({ discardResumeSession: true }) })).toBe(true);
+    expect(
+      isDiscardedSessionAttempt({
+        state: "failed",
+        errorJson: null,
+        metaJson: JSON.stringify({ discardResumeSession: true, freshSessionFailure: true }),
+      }),
+    ).toBe(false);
+  });
+
+  test("ordinary, quota, and malformed failures are untouched", () => {
+    expect(isDiscardedSessionAttempt(realFailureAttempt())).toBe(false);
+    expect(isDiscardedSessionAttempt(quotaAttempt())).toBe(false);
+    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: "{not json", metaJson: "{also not json" })).toBe(false);
+    expect(isDiscardedSessionAttempt(null)).toBe(false);
+    expect(isDiscardedSessionAttempt(undefined)).toBe(false);
+  });
+});
+
+describe("stampDurableRetryState budget accounting", () => {
+  const descriptor = { retries: 3 };
+  const error = { code: "AGENT_CLI_ERROR", message: "boom" };
+
+  /** @param {ReadonlyArray<unknown>} attempts */
+  function stamp(attempts) {
+    const attemptMeta = { kind: "agent" };
+    return stampDurableRetryState({ attemptMeta, attempts, descriptor, error, failedAtMs: 1_000 });
+  }
+
+  test("dead-session attempts do not advance the retry rung", () => {
+    const withSessionLosses = stamp([sessionLostAttempt(), sessionLostAttempt(), realFailureAttempt()]);
+    const withRealFailureOnly = stamp([realFailureAttempt()]);
+    expect(withSessionLosses?.failureCount).toBe(withRealFailureOnly?.failureCount);
+    expect(withSessionLosses?.failureCount).toBe(2);
+  });
+
+  test("a budget spent only on dead sessions and quota never exhausts", () => {
+    // Four bookkeeping failures against a retries=3 budget: still retryable.
+    const state = stamp([sessionLostAttempt(), quotaAttempt(), sessionLostAttempt(), quotaAttempt()]);
+    expect(state).not.toBeNull();
+    expect(state?.failureCount).toBe(1);
+  });
+
+  test("real failures still exhaust the budget", () => {
+    expect(stamp([realFailureAttempt(), realFailureAttempt(), realFailureAttempt()])).toBeNull();
+  });
+});
+
+describe("classifySessionLoss marks fresh-session failures", () => {
+  const stderr = "No conversation found with session ID: 68b187d0-a325-4384-a248-b2a0e6edbd90";
+
+  test("a resumed claude session is retryable bookkeeping", () => {
+    const error = classifySessionLoss("claude", stderr, stderr, true);
+    expect(error?.details?.discardResumeSession).toBe(true);
+    expect(error?.details?.freshSessionFailure).toBe(false);
+    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: JSON.stringify(error), metaJson: null })).toBe(true);
+  });
+
+  test("a fresh claude session failure consumes the budget so the chain fails over", () => {
+    const error = classifySessionLoss("claude", stderr, stderr, false);
+    expect(error?.details?.freshSessionFailure).toBe(true);
+    expect(isDiscardedSessionAttempt({ state: "failed", errorJson: JSON.stringify(error), metaJson: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
## The defect

A resumed agent CLI session whose persisted id is dead raises `AGENT_SESSION_LOST` with `discardResumeSession: true`. No work is dispatched — the agent throws the id away and the next attempt opens a fresh session, which the error message itself promises. The engine nonetheless counted it as an ordinary failure, so it consumed the task's retry budget.

Quota-limited attempts were already exempt for exactly this reason ("the run pauses until the quota resets and then retries as if the attempt never occurred"). Session losses are the same class of bookkeeping failure and were not exempt.

Observed on a real 7-lane run: one task's attempts were

1. heartbeat timeout (a real failure)
2. quota (correctly preserved)
3. **dead resume id (consumed a retry)**
4. quota (correctly preserved)
5. **dead resume id (consumed a retry)**

and the task died as "Attempt 5 of 3" having suffered exactly one real failure. Stale resume ids are routine for anyone running long tasks: the CLI prunes old conversations, machines restart, ids age out.

## The fix

A new `isDiscardedSessionAttempt` predicate, applied at the three sites that count retry-consuming attempts:

- `effect/retry-state.js` — `failureCount` for `stampDurableRetryState`
- `effect/workflow-bridge.js` — `retryConsumingFailures` in `classifyTaskAttempt`
- `engine.js` — the retry-rung counter and both `retryConsumingFailedAttempts` filters

Quota-specific park/resume logic is deliberately untouched: a session loss must never park a run waiting on a provider reset.

A session that broke even though the attempt started **fresh** still consumes the budget, so the task fails over to the next agent in the chain rather than retrying something that cannot succeed. The kimi classifier already reported that distinction via `freshSessionFailure`; the claude classifier now does too, with a message that says which case it is.

## Verification

- New `packages/engine/tests/discarded-session-retry-budget.test.js` (9 tests) pins the bug: it **fails on unmodified main** (`failureCount` 3 instead of 1) and passes with the fix. Covers meta-vs-error flag sources, malformed payloads, the fresh-session exclusion, and that real failures still exhaust the budget.
- `packages/engine`: 54 pass / 0 fail across the new file plus `engine-internals` and `failure-streak`.
- `packages/agents`: 42 pass / 0 fail across `classifyQuotaError` and `claude-support`.
- `oxlint` clean on every changed file (one pre-existing unrelated warning at `BaseCliAgent.js:622`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)