### PR TITLE
chore(defaults): use Fable 5.1 for new orchestrators

### DIFF
--- a/apps/ui/src/bun/Harnesses.test.ts
+++ b/apps/ui/src/bun/Harnesses.test.ts
@@ -106,7 +106,7 @@ describe("the table", () => {
       status: "unavailable",
       account: null,
       launch: { argv: ["claude"] },
-      models: { suggestions: ["claude-fable-5", "fable", "opus", "sonnet"], listable: false }
+      models: { suggestions: ["claude-fable-5-1", "claude-fable-5", "fable", "opus", "sonnet"], listable: false }
     })
     expect(h.probed).toEqual([])
   })

--- a/apps/ui/src/bun/Harnesses.ts
+++ b/apps/ui/src/bun/Harnesses.ts
@@ -189,7 +189,7 @@ export const DETECTORS: ReadonlyArray<Detector> = [
     binary: "claude",
     launch: ["claude"],
     /* `claude --help`: "--model <model> … an alias for the latest model (e.g. 'fable', 'opus', or 'sonnet') or a model's full name (e.g. 'claude-fable-5')". */
-    models: { flag: ["--model"], suggestions: ["claude-fable-5", "fable", "opus", "sonnet"] },
+    models: { flag: ["--model"], suggestions: ["claude-fable-5-1", "claude-fable-5", "fable", "opus", "sonnet"] },
     signal: (host) => {
       const state = readJson(host, join(host.home, ".claude.json"))
       const oauth = state?.oauthAccount

--- a/apps/ui/src/bun/routes/agents.test.ts
+++ b/apps/ui/src/bun/routes/agents.test.ts
@@ -140,9 +140,24 @@ describe("the agents routes", () => {
     expect(response.status).toBe(200)
     const body = AgentsResponseSchema.parse(await response.json())
     expect(body.agents.map((agent) => agent.id)).toEqual([...AGENT_ROLE_IDS])
+    expect(body.agents.find((agent) => agent.id === "orchestrator")?.model).toEqual({
+      provider: "anthropic", id: "claude-fable-5-1", label: "Fable 5.1"
+    })
     for (const agent of body.agents) {
       expect(agent.builtin).toBe(true)
       expect("launch" in agent).toBe(false)
+    }
+  })
+
+  test("a saved Fable 5 orchestrator is not silently upgraded when the store reopens", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "smithers-fable-"))
+    try {
+      const store = createAgentStore({ stateDir: dir })
+      const model = { provider: "anthropic", id: "claude-fable-5", label: "Fable 5" }
+      await store.put("orchestrator", { label: "Orchestrator", purpose: "Keep the selected model.", harness: "claude", model })
+      expect((await createAgentStore({ stateDir: dir }).get("orchestrator"))?.model).toEqual(model)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
     }
   })
 

--- a/apps/ui/src/mainview/AgentRoleMenu.test.ts
+++ b/apps/ui/src/mainview/AgentRoleMenu.test.ts
@@ -30,7 +30,7 @@ describe("the roles as the + menus list them", () => {
       "ui",
       "fast-ui"
     ])
-    expect(byId.orchestrator).toMatchObject({ title: "Orchestrator · Fable 5", available: true, account: "will@example.com" })
+    expect(byId.orchestrator).toMatchObject({ title: "Orchestrator · Fable 5.1", available: true, account: "will@example.com" })
     expect(byId.implementation).toMatchObject({ available: true, account: "OPENAI_API_KEY" })
     expect(byId["trivial-implementation"]).toMatchObject({ available: true })
     expect(byId.explainer).toMatchObject({ available: false, reason: "OpenCode · Kimi has no credential for Kimi K3" })

--- a/apps/ui/src/mainview/cards/AgentCards.test.tsx
+++ b/apps/ui/src/mainview/cards/AgentCards.test.tsx
@@ -1,4 +1,5 @@
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
+import { agentRole } from "@smthrs/rpc/AgentRoles"
 import { afterAll, describe, expect, test } from "bun:test"
 import { flushSync } from "react-dom"
 import { createRoot } from "react-dom/client"
@@ -32,7 +33,7 @@ const orchestrator: AgentsCard["payload"]["agents"][number] = {
   purpose: "Plans and delegates.",
   harness: "claude",
   harnessName: "Claude Code",
-  model: { provider: "anthropic", id: "claude-fable-5", label: "Fable 5" },
+  model: agentRole("orchestrator").model,
   builtin: true,
   available: true,
   reason: "",
@@ -88,7 +89,7 @@ describe("the Agents card", () => {
     const rows = [...host.querySelectorAll<HTMLElement>("[data-agent]")]
     expect(rows.map((row) => row.dataset.agent)).toEqual(["orchestrator", "reviewer", "docs-writer"])
     expect(rows[0]?.textContent).toContain("Orchestrator")
-    expect(rows[0]?.textContent).toContain("Claude Code · claude-fable-5 · ● will@example.com")
+    expect(rows[0]?.textContent).toContain("Claude Code · claude-fable-5-1 · ● will@example.com")
     expect(rows[1]?.textContent).toContain("Reviewer (mine)")
     expect(rows[2]?.textContent).toContain("○ OpenCode · Kimi has no credential for Kimi K3")
     // A built-in offers Launch and Edit, never Remove; a custom one offers Remove too; an unavailable one offers no Launch.

--- a/apps/ui/src/mainview/state/ComposerLayout.test.tsx
+++ b/apps/ui/src/mainview/state/ComposerLayout.test.tsx
@@ -388,7 +388,7 @@ describe("the composer's + menu and surface pill", () => {
       "Add files…",
       "New connector…",
       // The named roles (AgentRoles.ts): only the orchestrator's harness is installed in this fixture.
-      "Orchestrator · Fable 5will@example.com",
+      "Orchestrator · Fable 5.1will@example.com",
       "Explainer · Kimi K3opencode-kimi is not installed",
       "Implementation · GPT-5.6 Solcodex is not installed",
       "Trivial implementation · GPT-5.6 Lunacodex is not installed",

--- a/apps/ui/src/mainview/tabs/ChromeBar.test.tsx
+++ b/apps/ui/src/mainview/tabs/ChromeBar.test.tsx
@@ -215,7 +215,7 @@ describe("the + menu", () => {
     expect(items.at(-1)?.textContent).toBe("New agent…")
     expect(host.querySelector("[data-testid=tab-add-agents]")?.textContent).toBe("Agents")
     // Six role rows sit between Terminal and the first raw harness.
-    expect(items[1]?.textContent).toContain("Orchestrator · Fable 5")
+    expect(items[1]?.textContent).toContain("Orchestrator · Fable 5.1")
     expect(items[7]?.textContent).toContain("Claude Code")
     // The explainer's harness (OpenCode · Kimi) is absent from this fixture: disabled, with the reason.
     expect(items[2]?.disabled).toBe(true)

--- a/packages/rpc/src/AgentRoles.ts
+++ b/packages/rpc/src/AgentRoles.ts
@@ -23,7 +23,7 @@ import { HARNESS_IDS } from "./LocalApp.ts"
  * verified model flag and the guarded model id.
  *
  * Model ids and CLI flags are verified against the installed binaries:
- *  - `claude --model <model>` accepts a full model name ("claude-fable-5").
+ *  - `claude --model <model>` accepts a full model name ("claude-fable-5-1").
  *  - `codex -m <MODEL>` ("gpt-5.6-sol", "gpt-5.6-luna"; the same ids
  *    packages/smithers/agent/model/src/DeferredTools.ts lists for the GPT-5.6 family).
  *  - `opencode --model provider/model`: `opencode models kimi-for-coding`
@@ -101,7 +101,7 @@ export const AgentRoleModelSchema = z.object({
   provider: z.string(),
   /** The id the harness's model flag takes, verbatim. */
   id: ModelIdSchema,
-  /** The label the menus show ("Fable 5"). */
+  /** The label the menus show ("Fable 5.1"). */
   label: z.string()
 })
 /**
@@ -154,7 +154,7 @@ export const AGENT_ROLES: ReadonlyArray<AgentRole> = [
     id: "orchestrator",
     label: "Orchestrator",
     purpose: "The smartest agent: plans, writes workflows frame by frame, and delegates most work to the other roles.",
-    model: { provider: "anthropic", id: "claude-fable-5", label: "Fable 5" },
+    model: { provider: "anthropic", id: "claude-fable-5-1", label: "Fable 5.1" },
     harness: "claude",
     delegates: true
   }),

--- a/packages/rpc/test/AgentRoles.test.ts
+++ b/packages/rpc/test/AgentRoles.test.ts
@@ -43,7 +43,7 @@ describe("the agent role registry", () => {
       expect("launch" in role).toBe(false)
     }
     expect(agentRole("orchestrator")).toMatchObject({
-      model: { id: "claude-fable-5" },
+      model: { id: "claude-fable-5-1", label: "Fable 5.1" },
       harness: "claude",
       delegates: true
     })
@@ -98,11 +98,11 @@ describe("the agent role registry", () => {
   })
 
   test("the launch argv is composed per harness: binary, model flag, model id, then the task as the first prompt", () => {
-    expect(roleLaunchArgv(agentRole("orchestrator"), CLAUDE)).toEqual(["claude", "--model", "claude-fable-5"])
+    expect(roleLaunchArgv(agentRole("orchestrator"), CLAUDE)).toEqual(["claude", "--model", "claude-fable-5-1"])
     expect(roleLaunchArgv(agentRole("orchestrator"), CLAUDE, " plan it ")).toEqual([
       "claude",
       "--model",
-      "claude-fable-5",
+      "claude-fable-5-1",
       "plan it"
     ])
     expect(roleLaunchArgv(agentRole("implementation"), CODEX, "add a retry")).toEqual([
@@ -121,6 +121,15 @@ describe("the agent role registry", () => {
       "why did this fail"
     ])
     expect(roleLaunchArgv(agentRole("ui"), OPENCODE, "   ")).toEqual(["opencode", "--model", "kimi-for-coding/k3"])
+  })
+
+  test("an explicit Fable 5 selection remains valid and launches unchanged", () => {
+    const role = {
+      ...agentRole("orchestrator"),
+      model: { provider: "anthropic", id: "claude-fable-5", label: "Fable 5" }
+    }
+    expect(AgentRoleSchema.safeParse(role).success).toBe(true)
+    expect(roleLaunchArgv(role, CLAUDE)).toEqual(["claude", "--model", "claude-fable-5"])
   })
 
   test("renderer input never reaches argv verbatim: a model id that is a flag is refused at composition", () => {


### PR DESCRIPTION
Changes the new-orchestrator default and first Claude suggestion to `claude-fable-5-1`. Saved model selections remain unchanged.

Closed: no defect in the existing default was demonstrated. This is a default-model policy change, not a bug fix. Related issue: #1639.

Validation: 170 RPC tests and 66 UI tests passed; RPC lint/typecheck and a focused rendered preview passed. Full UI setup was blocked by the Electrobun/Hutch download; full repository CI and live-provider validation were not completed.